### PR TITLE
fix: explicit import map for Deno 2

### DIFF
--- a/.github/actions/bump.ts
+++ b/.github/actions/bump.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx deno run --allow-net --allow-run --allow-read --allow-write --allow-env --unstable
+#!/usr/bin/env -S pkgx deno run --allow-net --allow-run --allow-read --allow-write --allow-env
 
 import { backticks, run, panic } from "utils"
 import { basename } from "deno/path/mod.ts"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,21 +1,16 @@
 {
-  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "imports": {
-    "path": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/vendor/Path.ts",
-    "types": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/types.ts",
-    "hooks": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/hooks/index.ts",
-    "hooks/": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/hooks/",
-    "prefab": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/prefab/index.ts",
-    "prefab/": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/prefab/",
-    "deno/": "https://deno.land/std@0.173.0/",
-    "semver": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/utils/semver.ts",
-    "utils": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/utils/index.ts",
-    "utils/": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/utils/",
-    "is_what": "https://deno.land/x/is_what@v4.1.7/src/index.ts",
-    "cliffy/": "https://deno.land/x/cliffy@v0.25.2/",
-    "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
-    "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
-    "sha256": "https://deno.land/std@0.160.0/hash/sha256.ts",
-    "rimbu/": "https://deno.land/x/rimbu@0.12.3/"
+    "@cliffy/ansi": "jsr:@cliffy/ansi@^1.0.0-rc.7",
+    "@std/assert": "jsr:@std/assert@^1.0.6",
+    "@std/fmt": "jsr:@std/fmt@^1.0.2",
+    "@std/io": "jsr:@std/io@^0.225.0",
+    "@std/jsonc": "jsr:@std/jsonc@^1.0.1",
+    "@std/path": "jsr:@std/path@^1.0.6",
+    "@std/testing": "jsr:@std/testing@^1.0.3",
+    "@std/yaml": "jsr:@std/yaml@^1.0.5",
+    "is-what": "https://deno.land/x/is_what@v4.1.15/src/index.ts",
+    "outdent": "jsr:@cspotcode/outdent@^0.8",
+    "pkgx": "https://deno.land/x/libpkgx@v0.20.0/mod.ts",
+    "pkgx/": "https://deno.land/x/libpkgx@v0.20.0/src/"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,3 +1,21 @@
 {
-  "importMap": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/import-map.json"
+  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
+  "imports": {
+    "path": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/vendor/Path.ts",
+    "types": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/types.ts",
+    "hooks": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/hooks/index.ts",
+    "hooks/": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/hooks/",
+    "prefab": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/prefab/index.ts",
+    "prefab/": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/prefab/",
+    "deno/": "https://deno.land/std@0.173.0/",
+    "semver": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/utils/semver.ts",
+    "utils": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/utils/index.ts",
+    "utils/": "https://raw.githubusercontent.com/pkgxdev/pkgx/v0.21/src/utils/",
+    "is_what": "https://deno.land/x/is_what@v4.1.7/src/index.ts",
+    "cliffy/": "https://deno.land/x/cliffy@v0.25.2/",
+    "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
+    "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
+    "sha256": "https://deno.land/std@0.160.0/hash/sha256.ts",
+    "rimbu/": "https://deno.land/x/rimbu@0.12.3/"
+  }
 }


### PR DESCRIPTION
- HTTP import maps were removed in Deno 2
- `--unstable` flag was removed in Deno 2